### PR TITLE
fix(readme): fixed cdk plugin property for README

### DIFF
--- a/API.md
+++ b/API.md
@@ -34,7 +34,7 @@ import { KicsValidator } from '@checkmarx/cdk-validator-kics/lib/plugin';
 
 ```ts
 new App({
-  validationPlugins: [
+  policyValidationBeta1: [
     new KicsValidator(),
   ],
 });

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import { KicsValidator } from '@checkmarx/cdk-validator-kics/lib/plugin';
 
 ```ts
 new App({
-  validationPlugins: [
+  policyValidationBeta1: [
     new KicsValidator(),
   ],
 });
@@ -94,4 +94,3 @@ new KicsValidator({
   ],
 });
 ```
-

--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ new KicsValidator({
   ],
 });
 ```
+


### PR DESCRIPTION
# What does it Fix?

- The property of CDK which README uses is wrong. 

- According to CDK docs, only[ policyvalidationbeta1 ](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.App.html#policyvalidationbeta1 )property exist.　There is no reference of `validationPlugins`

# Motivation

- If someone tries this plugin following the current state of README won't be able to use the plugin until they go and search CDK docs which is not nice from an experience point of view.

# Verification 

- I have verified this in my blog https://dev.to/aws-builders/level-up-your-aws-cdk-game-shift-left-security-unveiled-5f54 and it works with the changes I have proposed in this PR.

- The following information has also been verified by AWS team author of [aws  blog ](https://aws.amazon.com/blogs/apn/how-to-shift-left-security-in-infrastructure-as-code-using-aws-cdk-and-checkmarx-kics/)and I have asked the authors to update the blog too.