### PR TITLE
update readme on `fail-on` status

### DIFF
--- a/API.md
+++ b/API.md
@@ -83,8 +83,10 @@ new KicsValidator({
 });
 ```
 
-The other option is to provide `failureSeverities` if you still want to show
-the query in the results, but you don't want it to fail the execution.
+Alternatively, you can use the `failureSeverities` parameter when initiating a scan, enabling you to precisely define the criteria for considering a scan unsuccessful based on the severity of its results. Any result with a severity lower than the specified ones will not prompt a failure.
+
+Please note that scans configured to only fail on certain severity levels might not display results falling below those specified levels.
+
 By default this is set to `[Severity.HIGH, Severity.MEDIUM]`.
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ new KicsValidator({
 });
 ```
 
-The other option is to provide `failureSeverities` if you still want to show
-the query in the results, but you don't want it to fail the execution.
+Alternatively, you can use the `failureSeverities` parameter when initiating a scan, enabling you to precisely define the criteria for considering a scan unsuccessful based on the severity of its results. Any result with a severity lower than the specified ones will not prompt a failure.
+
+Please note that scans configured to only fail on certain severity levels might not display results falling below those specified levels.
+
 By default this is set to `[Severity.HIGH, Severity.MEDIUM]`.
 
 ```ts


### PR DESCRIPTION
closes #21 
propose changes:
- update readme on `fail-on` status, to better explain how it works.