### PR TITLE
fix(test) update test public bucket creation

### DIFF
--- a/test/plugin.integ.test.ts
+++ b/test/plugin.integ.test.ts
@@ -33,7 +33,7 @@ describe('KicsValidator', () => {
         blockPublicPolicy: false,
         ignorePublicAcls: false,
         restrictPublicBuckets: false,
-      }
+      },
     });
 
 

--- a/test/plugin.integ.test.ts
+++ b/test/plugin.integ.test.ts
@@ -28,6 +28,12 @@ describe('KicsValidator', () => {
     const stack = new Stack(app, 'Stack');
     new s3.Bucket(stack, 'Bucket', {
       publicReadAccess: true,
+      blockPublicAccess: {
+        blockPublicAcls: false,
+        blockPublicPolicy: false,
+        ignorePublicAcls: false,
+        restrictPublicBuckets: false,
+      }
     });
 
 


### PR DESCRIPTION
proposed changes:
- update s3.New configs to avoid error `Cannot use 'publicReadAccess' property on a bucket without allowing bucket-level public access through 'blockPublicAceess' property.` in test